### PR TITLE
Fix accuracy issues for both Keras (all models) and PyTorch (inception_v3)

### DIFF
--- a/imagenet_pytorch_get_predictions.py
+++ b/imagenet_pytorch_get_predictions.py
@@ -92,7 +92,7 @@ def main(args = parser.parse_args()):
     dataloaders = {}
     for img_size in [224, 299]:
         val_transform = transforms.Compose([
-            transforms.Resize(256),
+            transforms.Resize(int(img_size / 0.875)),
             transforms.CenterCrop(img_size),
             transforms.ToTensor(),
             transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
@@ -132,7 +132,8 @@ def process_model(
     model = model.to(device)
     wfn_base = os.path.join(out_dir, model_name + "_pytorch_imagenet_")
     probs, labels = [], []
-    loader = dataloaders[299] if model_name is "inception_v3" else dataloaders[224]
+
+    loader = dataloaders[299] if model_name == "inception_v3" else dataloaders[224]
     
     # Inference, with no gradient changing
     model.eval() # set model to inference mode (not train mode)


### PR DESCRIPTION
This should improve accuracy as it makes preprocessing consistent with typical imagenet handling. I'm not sure why Keras makes this so difficult. I defaulted the crop scaling to 0.875 for all, but some models, especially larger inception/xception/nasnet may work better with a larger value. I've seen 0.8975 used in places.

Inception_v3 in PyTorch now produces, acc1: 77.32%, acc5: 93.43%

ResNet50 in Keras, acc1: 74.79%, acc5: 91.96%
