### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/imagenet_pytorch_get_predictions.py
+++ b/imagenet_pytorch_get_predictions.py
@@ -132,7 +132,7 @@ def process_model(
     model = model.to(device)
     wfn_base = os.path.join(out_dir, model_name + "_pytorch_imagenet_")
     probs, labels = [], []
-    loader = dataloaders[299] if model_name is "inception_v3" else dataloaders[224]
+    loader = dataloaders[299] if model_name == "inception_v3" else dataloaders[224]
     
     # Inference, with no gradient changing
     model.eval() # set model to inference mode (not train mode)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/cgnorthcutt/benchmarking-keras-pytorch on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./imagenet_pytorch_get_predictions.py:135:34: F632 use ==/!= to compare str, bytes, and int literals
    loader = dataloaders[299] if model_name is "inception_v3" else dataloaders[224]
                                 ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree